### PR TITLE
make alert messages for OUTSIDE mode consistent with its test condition

### DIFF
--- a/check_cloudwatch.sh
+++ b/check_cloudwatch.sh
@@ -267,7 +267,7 @@ function shouldAlert
                 MESSAGE="VALUE is ok. The value is >= ${THRESHOLD_MIN}";
                 EXIT=0;
             else
-                MESSAGE="VALUE is too high. The value SHOULD BE >= ${THRESHOLD_MIN}";
+                MESSAGE="VALUE is too low. The value SHOULD BE >= ${THRESHOLD_MIN}";
                 EXIT=1;
             fi;
         elif [[ "${THRESHOLD_MIN}" == "~" ]];
@@ -277,7 +277,7 @@ function shouldAlert
                 MESSAGE="VALUE is ok. The value is <= ${THRESHOLD_MAX}";
                 EXIT=0;
             else
-                MESSAGE="VALUE is too low. The value SHOULD BE <= ${THRESHOLD_MAX}";
+                MESSAGE="VALUE is too high. The value SHOULD BE <= ${THRESHOLD_MAX}";
                 EXIT=1;
             fi;
         elif [[ 1 -eq "$(echo "${METRIC_VALUE} < ${THRESHOLD_MIN}" | bc)" ]] || [[ 1 -eq "$(echo "${METRIC_VALUE} > ${THRESHOLD_MAX}" | bc)" ]];


### PR DESCRIPTION
The alert message for a threshold value of "42949672960:" and a metric value "42753052672" should be "VALUE is too low", not "VALUE is too high".

Current behaviour:

```
--- 42949672960:, test with value: 42753052672 ---
Running in OUTSIDE mode (alert if value is outside range {42949672960 ... ~})
Should alert: 1 - VALUE is too high. The value SHOULD BE >= 42949672960
```

Likewise, the alert message for a threshold value of "~:42649672960" and a metric value of "42751098880" should be "VALUE is too high", not "VALUE is too low".

Current behaviour:

```
--- ~:42649672960, test with value: 42751098880 ---
Running in OUTSIDE mode (alert if value is outside range {~ ... 42649672960})
Should alert: 1 - VALUE is too low. The value SHOULD BE <= 42649672960
```