### PR TITLE
Added a fix so that this script can handle Scientific values like 9.610487596832052e-06

### DIFF
--- a/check_cloudwatch.sh
+++ b/check_cloudwatch.sh
@@ -542,6 +542,10 @@ fi
 
 
 METRIC_VALUE=$(echo ${RESULT} | jq ".Datapoints[0].${STATISTICS}")
+
+# Make sure that Scientific value is converted to floats
+printf -v METRIC_VALUE '%.9f' $METRIC_VALUE
+
 UNIT=$(echo ${RESULT} | jq -r ".Datapoints[0].Unit")
 verbose "Raw result: ${RESULT}";
 verbose "Unit: ${UNIT}";


### PR DESCRIPTION
This should solve issue #25. 

Executed test:
```
METRIC_VALUE=9.610487596832052e-06

# Make sure that Scientific value is converted to floats
printf -v METRIC_VALUE '%.9f' $METRIC_VALUE

# --warning= --critical=~:0.5
# Warning: >0.2
# Critical: > 0.5
shouldAlert "~:0.2" "${METRIC_VALUE}"
shouldAlert "~:0.5" "${METRIC_VALUE}"
```

Result: 
```--- ~:0.2, test with value: 0.000009610 ---
Running in OUTSIDE mode (alert if value is outside range {~ ... 0.2})
0.000009610 <= 0.2
Should alert: 0 - VALUE is ok. The value is <= 0.2

--- ~:0.5, test with value: 0.000009610 ---
Running in OUTSIDE mode (alert if value is outside range {~ ... 0.5})
0.000009610 <= 0.5
Should alert: 0 - VALUE is ok. The value is <= 0.5
```